### PR TITLE
Moviendo la configuracion del usuario al inicio despues del clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Repositorio de trabajo de los integrantes de la comunidad Data Science Research 
 
 Haz los siguientes pasos:
 * Clona el repositorio de `https://github.com/DataScienceResearchPeru/GithubParticipantes` a `https://github.com/<tu-usuario>/GithubParticipantes` dando clic en el botón "Fork":![](https://image.ibb.co/k3Oh9v/Screenshot_from_2017_08_06_22_10_12.png)
-
+* Configura tus datos de usuario:
+    * `git config --global user.email "tu-email@gmail.com"`
+    * `git config --global user.name "<tu-usuario>"`
 * Después añade tu remote a la lista de remotes: 
     * `git remote add pr https://github.com/<tu-usuario>/GithubParticipantes.git`
 * Verifica que fue añadido tu remote: 
@@ -16,9 +18,6 @@ Haz los siguientes pasos:
 `git add .`
 * Añade tu commit: 
 `git commit -m "Aquí pon una descripción de los cambios."`
-* Configura tus datos de usuario:
-    * `git config --global user.email "tu-email@gmail.com"`
-    * `git config --global user.name "<tu-usuario>"`
 * Haz push de tu commit a tu fork del repositorio: `git push pr master`
 * En la pagina web, en tu fork del repositorio, haz clic en "Pull request":
 ![](https://image.ibb.co/gM0ZNF/Screenshot_from_2017_08_06_22_16_08.png)


### PR DESCRIPTION
En mi opinion deberiamos configurar las credenciales de autenticacion primero despues de hacer el clone de un repositorio.